### PR TITLE
Kylehuynh205 search highlight

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -4104,17 +4104,17 @@
         },
         {
             "name": "drupal/rest_oai_pmh",
-            "version": "2.0.0-beta11",
+            "version": "2.0.0-beta12",
             "source": {
                 "type": "git",
                 "url": "https://git.drupalcode.org/project/rest_oai_pmh.git",
-                "reference": "2.0.0-beta11"
+                "reference": "2.0.0-beta12"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://ftp.drupal.org/files/projects/rest_oai_pmh-2.0.0-beta11.zip",
-                "reference": "2.0.0-beta11",
-                "shasum": "67234bc12b5c316405e6da231a5081518a348e05"
+                "url": "https://ftp.drupal.org/files/projects/rest_oai_pmh-2.0.0-beta12.zip",
+                "reference": "2.0.0-beta12",
+                "shasum": "83a2ffcf6e61085548ecda2d84a9d43bea9bccab"
             },
             "require": {
                 "drupal/core": "^9 || ^10"
@@ -4122,8 +4122,8 @@
             "type": "drupal-module",
             "extra": {
                 "drupal": {
-                    "version": "2.0.0-beta11",
-                    "datestamp": "1685966589",
+                    "version": "2.0.0-beta12",
+                    "datestamp": "1686681467",
                     "security-coverage": {
                         "status": "not-covered",
                         "message": "Beta releases are not covered by Drupal security advisories."
@@ -4224,30 +4224,29 @@
         },
         {
             "name": "drupal/search_api_solr",
-            "version": "4.2.10",
+            "version": "4.2.12",
             "source": {
                 "type": "git",
                 "url": "https://git.drupalcode.org/project/search_api_solr.git",
-                "reference": "4.2.10"
+                "reference": "4.2.12"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://ftp.drupal.org/files/projects/search_api_solr-4.2.10.zip",
-                "reference": "4.2.10",
-                "shasum": "28b1ccd5c462db92af3561103e9a33569a674387"
+                "url": "https://ftp.drupal.org/files/projects/search_api_solr-4.2.12.zip",
+                "reference": "4.2.12",
+                "shasum": "3e6c7b22cdd1339e8373f700fdfdec332ea24e02"
             },
             "require": {
                 "composer/semver": "^1.0|^3.0",
                 "consolidation/annotated-command": "^2.12|^4.1",
                 "drupal/core": "^9.3 || ^10.0",
-                "drupal/search_api": "~1.28",
+                "drupal/search_api": "~1.29",
                 "ext-dom": "*",
                 "ext-json": "*",
                 "ext-simplexml": "*",
                 "laminas/laminas-stdlib": "^3.2",
-                "maennchen/zipstream-php": "^2.2.1",
-                "php": ">=7.4",
-                "solarium/solarium": "^6.2.8"
+                "maennchen/zipstream-php": "^2.2.1|^3.0.2",
+                "solarium/solarium": "^6.3.0"
             },
             "conflict": {
                 "drupal/acquia_search_solr": "<1.0.0-beta8",
@@ -4273,8 +4272,8 @@
             "type": "drupal-module",
             "extra": {
                 "drupal": {
-                    "version": "4.2.10",
-                    "datestamp": "1671442326",
+                    "version": "4.2.12",
+                    "datestamp": "1687445036",
                     "security-coverage": {
                         "status": "covered",
                         "message": "Covered by Drupal's security advisory policy"
@@ -4533,17 +4532,17 @@
         },
         {
             "name": "drupal/token",
-            "version": "1.11.0",
+            "version": "1.12.0",
             "source": {
                 "type": "git",
                 "url": "https://git.drupalcode.org/project/token.git",
-                "reference": "8.x-1.11"
+                "reference": "8.x-1.12"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://ftp.drupal.org/files/projects/token-8.x-1.11.zip",
-                "reference": "8.x-1.11",
-                "shasum": "da264b36d1f88eb0c74bf84e18e8789854f98400"
+                "url": "https://ftp.drupal.org/files/projects/token-8.x-1.12.zip",
+                "reference": "8.x-1.12",
+                "shasum": "cefe1b203b793682f74ea43e18d0a814cf768763"
             },
             "require": {
                 "drupal/core": "^9.2 || ^10"
@@ -4551,8 +4550,8 @@
             "type": "drupal-module",
             "extra": {
                 "drupal": {
-                    "version": "8.x-1.11",
-                    "datestamp": "1659471813",
+                    "version": "8.x-1.12",
+                    "datestamp": "1688015262",
                     "security-coverage": {
                         "status": "covered",
                         "message": "Covered by Drupal's security advisory policy"
@@ -5200,16 +5199,16 @@
         },
         {
             "name": "firebase/php-jwt",
-            "version": "v6.7.0",
+            "version": "v6.8.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/firebase/php-jwt.git",
-                "reference": "71278f20b0a623389beefe87a641d03948a38870"
+                "reference": "48b0210c51718d682e53210c24d25c5a10a2299b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/firebase/php-jwt/zipball/71278f20b0a623389beefe87a641d03948a38870",
-                "reference": "71278f20b0a623389beefe87a641d03948a38870",
+                "url": "https://api.github.com/repos/firebase/php-jwt/zipball/48b0210c51718d682e53210c24d25c5a10a2299b",
+                "reference": "48b0210c51718d682e53210c24d25c5a10a2299b",
                 "shasum": ""
             },
             "require": {
@@ -5257,9 +5256,9 @@
             ],
             "support": {
                 "issues": "https://github.com/firebase/php-jwt/issues",
-                "source": "https://github.com/firebase/php-jwt/tree/v6.7.0"
+                "source": "https://github.com/firebase/php-jwt/tree/v6.8.0"
             },
-            "time": "2023-06-14T15:29:26+00:00"
+            "time": "2023-06-20T16:45:35+00:00"
         },
         {
             "name": "grasmash/expander",
@@ -5664,17 +5663,75 @@
             "time": "2023-04-17T16:00:37+00:00"
         },
         {
+            "name": "halaxa/json-machine",
+            "version": "1.1.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/halaxa/json-machine.git",
+                "reference": "514025c5ebbdb8a058745b573b4a1e81d685802c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/halaxa/json-machine/zipball/514025c5ebbdb8a058745b573b4a1e81d685802c",
+                "reference": "514025c5ebbdb8a058745b573b4a1e81d685802c",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.0"
+            },
+            "require-dev": {
+                "ext-json": "*",
+                "friendsofphp/php-cs-fixer": "^3.0",
+                "phpunit/phpunit": "^8.0"
+            },
+            "suggest": {
+                "ext-json": "To run JSON Machine out of the box without custom decoders.",
+                "guzzlehttp/guzzle": "To run example with GuzzleHttp"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "JsonMachine\\": "src/"
+                },
+                "exclude-from-classmap": [
+                    "src/autoloader.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "Apache-2.0"
+            ],
+            "authors": [
+                {
+                    "name": "Filip Halaxa",
+                    "email": "filip@halaxa.cz"
+                }
+            ],
+            "description": "Efficient, easy-to-use and fast JSON pull parser",
+            "support": {
+                "issues": "https://github.com/halaxa/json-machine/issues",
+                "source": "https://github.com/halaxa/json-machine/tree/1.1.3"
+            },
+            "funding": [
+                {
+                    "url": "https://ko-fi.com/G2G57KTE4",
+                    "type": "other"
+                }
+            ],
+            "time": "2022-10-12T11:40:33+00:00"
+        },
+        {
             "name": "islandora-rdm/islandora_fits",
             "version": "dev-8.x-1.x",
             "source": {
                 "type": "git",
                 "url": "https://github.com/roblib/islandora_fits.git",
-                "reference": "f03b4eeff3598a9b81aad614f8aecd62cf14d81d"
+                "reference": "700449c7dfc7211e09fccd5982f4287e422301c1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/roblib/islandora_fits/zipball/f03b4eeff3598a9b81aad614f8aecd62cf14d81d",
-                "reference": "f03b4eeff3598a9b81aad614f8aecd62cf14d81d",
+                "url": "https://api.github.com/repos/roblib/islandora_fits/zipball/700449c7dfc7211e09fccd5982f4287e422301c1",
+                "reference": "700449c7dfc7211e09fccd5982f4287e422301c1",
                 "shasum": ""
             },
             "require": {
@@ -5695,17 +5752,60 @@
                 "issues": "https://www.drupal.org/project/issues/islandora_fits",
                 "source": "http://cgit.drupalcode.org/islandora_fits"
             },
-            "time": "2022-09-23T14:27:40+00:00"
+            "time": "2023-06-22T18:50:38+00:00"
         },
         {
             "name": "islandora/advanced_search",
             "version": "2.0.0-beta3",
             "source": {
                 "type": "git",
-                "url": "https://github.com/digitalutsc/advanced_search",
-                "reference": "2.0.0-beta3"
+                "url": "https://github.com/digitalutsc/advanced_search.git",
+                "reference": "fe6bfe51d1987d571d1b6c65b07043dd7aa9d917"
             },
-            "type": "drupal-module"
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/digitalutsc/advanced_search/zipball/fe6bfe51d1987d571d1b6c65b07043dd7aa9d917",
+                "reference": "fe6bfe51d1987d571d1b6c65b07043dd7aa9d917",
+                "shasum": ""
+            },
+            "require": {
+                "drupal/facets": "^2.0",
+                "drupal/search_api_solr": "^4.2"
+            },
+            "require-dev": {
+                "drupal/coder": "*",
+                "phpunit/phpunit": "^8",
+                "sebastian/phpcpd": "*",
+                "squizlabs/php_codesniffer": "^3"
+            },
+            "default-branch": true,
+            "type": "drupal-module",
+            "scripts": {
+                "post-install-cmd": [
+                    "./vendor/bin/phpcs --config-set installed_paths ~/.composer/vendor/drupal/coder/coder_sniffer"
+                ],
+                "post-update-cmd": [
+                    "./vendor/bin/phpcs --config-set installed_paths ~/.composer/vendor/drupal/coder/coder_sniffer"
+                ],
+                "check": [
+                    "./vendor/bin/phpcs --standard=Drupal --ignore=*.md,vendor --extensions=php,module,inc,install,test,profile,theme,css,info .",
+                    "./vendor/bin/phpcpd --names='*.module,*.inc,*.test,*.php' --exclude=vendor ."
+                ]
+            },
+            "license": [
+                "GPL-2.0-only"
+            ],
+            "description": "This module creates several blocks to support searching. It also enables the use of Ajax with search blocks, facets, and search results.",
+            "homepage": "https://github.com/digitalutsc/advanced_search",
+            "keywords": [
+                "Advanced Search",
+                "Islandora"
+            ],
+            "support": {
+                "issues": "https://github.com/digitalutsc/advanced_search/issues",
+                "source": "https://github.com/digitalutsc/advanced_search/tree/islandora_lite"
+            },
+            "time": "2023-06-28T21:04:54+00:00"
         },
         {
             "name": "islandora/chullo",
@@ -6059,16 +6159,16 @@
         },
         {
             "name": "islandora/views_nested_details",
-            "version": "1.0.0",
+            "version": "1.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Islandora-Labs/views_nested_details.git",
-                "reference": "f004bd1f7fcd806e1c1a483be4ae83f34e539fe7"
+                "reference": "8c9d63e8d997864ea3ca9a214f1ed55d990b31f9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Islandora-Labs/views_nested_details/zipball/f004bd1f7fcd806e1c1a483be4ae83f34e539fe7",
-                "reference": "f004bd1f7fcd806e1c1a483be4ae83f34e539fe7",
+                "url": "https://api.github.com/repos/Islandora-Labs/views_nested_details/zipball/8c9d63e8d997864ea3ca9a214f1ed55d990b31f9",
+                "reference": "8c9d63e8d997864ea3ca9a214f1ed55d990b31f9",
                 "shasum": ""
             },
             "type": "drupal-module",
@@ -6080,9 +6180,9 @@
             "homepage": "https://github.com/Islandora-Labs/views_nested_details",
             "support": {
                 "issues": "https://github.com/Islandora-Labs/views_nested_details/issues",
-                "source": "https://github.com/Islandora-Labs/views_nested_details/tree/1.0.0"
+                "source": "https://github.com/Islandora-Labs/views_nested_details/tree/1.1.0"
             },
-            "time": "2023-03-01T15:59:32+00:00"
+            "time": "2023-06-02T12:22:40+00:00"
         },
         {
             "name": "laminas/laminas-escaper",
@@ -7206,16 +7306,16 @@
         },
         {
             "name": "nikic/php-parser",
-            "version": "v4.15.5",
+            "version": "v4.16.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/nikic/PHP-Parser.git",
-                "reference": "11e2663a5bc9db5d714eedb4277ee300403b4a9e"
+                "reference": "19526a33fb561ef417e822e85f08a00db4059c17"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/11e2663a5bc9db5d714eedb4277ee300403b4a9e",
-                "reference": "11e2663a5bc9db5d714eedb4277ee300403b4a9e",
+                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/19526a33fb561ef417e822e85f08a00db4059c17",
+                "reference": "19526a33fb561ef417e822e85f08a00db4059c17",
                 "shasum": ""
             },
             "require": {
@@ -7256,9 +7356,9 @@
             ],
             "support": {
                 "issues": "https://github.com/nikic/PHP-Parser/issues",
-                "source": "https://github.com/nikic/PHP-Parser/tree/v4.15.5"
+                "source": "https://github.com/nikic/PHP-Parser/tree/v4.16.0"
             },
-            "time": "2023-05-19T20:20:00+00:00"
+            "time": "2023-06-25T14:52:30+00:00"
         },
         {
             "name": "pear/archive_tar",
@@ -8074,21 +8174,22 @@
         },
         {
             "name": "solarium/solarium",
-            "version": "6.2.8",
+            "version": "6.3.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/solariumphp/solarium.git",
-                "reference": "0bca4fdcd53e86dea19754b0081f91fe17248a9d"
+                "reference": "2c3d36d0e35fa88e386c80958b0b106f947fdce1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/solariumphp/solarium/zipball/0bca4fdcd53e86dea19754b0081f91fe17248a9d",
-                "reference": "0bca4fdcd53e86dea19754b0081f91fe17248a9d",
+                "url": "https://api.github.com/repos/solariumphp/solarium/zipball/2c3d36d0e35fa88e386c80958b0b106f947fdce1",
+                "reference": "2c3d36d0e35fa88e386c80958b0b106f947fdce1",
                 "shasum": ""
             },
             "require": {
                 "composer-runtime-api": ">=2.0",
                 "ext-json": "*",
+                "halaxa/json-machine": "^1.1",
                 "php": "^7.3 || ^8.0",
                 "psr/event-dispatcher": "^1.0",
                 "psr/http-client": "^1.0",
@@ -8097,15 +8198,15 @@
             },
             "require-dev": {
                 "escapestudios/symfony2-coding-standard": "^3.11",
+                "ext-curl": "*",
                 "ext-iconv": "*",
-                "guzzlehttp/guzzle": "^7.2",
-                "nyholm/psr7": "^1.2",
-                "php-http/guzzle7-adapter": "^0.1",
+                "nyholm/psr7": "^1.8",
+                "php-http/guzzle7-adapter": "^1.0",
                 "phpstan/extension-installer": "^1.0",
                 "phpstan/phpstan": "^1.0",
                 "phpstan/phpstan-deprecation-rules": "^1.0",
                 "phpstan/phpstan-phpunit": "^1.0",
-                "phpunit/phpunit": "^9.5",
+                "phpunit/phpunit": "^9.6",
                 "roave/security-advisories": "dev-master",
                 "symfony/event-dispatcher": "^4.3 || ^5.0 || ^6.0"
             },
@@ -8134,9 +8235,9 @@
             ],
             "support": {
                 "issues": "https://github.com/solariumphp/solarium/issues",
-                "source": "https://github.com/solariumphp/solarium/tree/6.2.8"
+                "source": "https://github.com/solariumphp/solarium/tree/6.3.1"
             },
-            "time": "2022-12-06T10:22:19+00:00"
+            "time": "2023-06-22T14:24:00+00:00"
         },
         {
             "name": "stack/builder",
@@ -8194,16 +8295,16 @@
         },
         {
             "name": "stomp-php/stomp-php",
-            "version": "5.0.0",
+            "version": "5.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/stomp-php/stomp-php.git",
-                "reference": "50f6e6e9aa1ba4696faa40cd1cbe180a96679f98"
+                "reference": "cf1fbd79cf48b9701909e42205f1d968cec6ff7a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/stomp-php/stomp-php/zipball/50f6e6e9aa1ba4696faa40cd1cbe180a96679f98",
-                "reference": "50f6e6e9aa1ba4696faa40cd1cbe180a96679f98",
+                "url": "https://api.github.com/repos/stomp-php/stomp-php/zipball/cf1fbd79cf48b9701909e42205f1d968cec6ff7a",
+                "reference": "cf1fbd79cf48b9701909e42205f1d968cec6ff7a",
                 "shasum": ""
             },
             "require": {
@@ -8251,7 +8352,7 @@
             ],
             "support": {
                 "issues": "https://github.com/stomp-php/stomp-php/issues",
-                "source": "https://github.com/stomp-php/stomp-php/tree/5.0.0"
+                "source": "https://github.com/stomp-php/stomp-php/tree/5.1.0"
             },
             "funding": [
                 {
@@ -8263,7 +8364,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2021-02-02T19:25:59+00:00"
+            "time": "2023-06-19T17:34:28+00:00"
         },
         {
             "name": "symfony-cmf/routing",
@@ -10678,16 +10779,16 @@
         },
         {
             "name": "symfony/var-dumper",
-            "version": "v5.4.24",
+            "version": "v5.4.25",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/var-dumper.git",
-                "reference": "8e12706bf9c68a2da633f23bfdc15b4dce5970b3"
+                "reference": "82269f73c0f0f9859ab9b6900eebacbe54954ede"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/var-dumper/zipball/8e12706bf9c68a2da633f23bfdc15b4dce5970b3",
-                "reference": "8e12706bf9c68a2da633f23bfdc15b4dce5970b3",
+                "url": "https://api.github.com/repos/symfony/var-dumper/zipball/82269f73c0f0f9859ab9b6900eebacbe54954ede",
+                "reference": "82269f73c0f0f9859ab9b6900eebacbe54954ede",
                 "shasum": ""
             },
             "require": {
@@ -10746,7 +10847,7 @@
                 "dump"
             ],
             "support": {
-                "source": "https://github.com/symfony/var-dumper/tree/v5.4.24"
+                "source": "https://github.com/symfony/var-dumper/tree/v5.4.25"
             },
             "funding": [
                 {
@@ -10762,7 +10863,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-05-25T13:05:00+00:00"
+            "time": "2023-06-20T20:56:26+00:00"
         },
         {
             "name": "symfony/yaml",

--- a/config/sync/advanced_search.settings.yml
+++ b/config/sync/advanced_search.settings.yml
@@ -1,11 +1,11 @@
-search_query_parameter: a
-search_recursive_parameter: r
-search_add_operator: +
-search_remove_operator: '-'
-facet_truncate: '32'
 lucene_on_off: 1
 lucene_label: Keyword
 all_fields_on_off: 1
 list_on_off: 1
 grid_on_off: 1
 default-display-mode: list
+search_query_parameter: a
+search_recursive_parameter: r
+search_add_operator: +
+search_remove_operator: '-'
+facet_truncate: '32'

--- a/config/sync/search_api.index.default_solr_index.yml
+++ b/config/sync/search_api.index.default_solr_index.yml
@@ -492,9 +492,14 @@ processor_settings:
     excerpt_always: true
     excerpt_length: 256
     exclude_fields:
+      - abstract_description_fulltext
       - field_description
       - field_full_title
+      - linked_agent_name_fulltext
+      - rendered_item
+      - subject_aggregated_fulltext
       - title
+      - title_aggregated_fulltext
     highlight: always
     highlight_partial: true
   html_filter:

--- a/config/sync/search_api.server.default_solr_server.yml
+++ b/config/sync/search_api.server.default_solr_server.yml
@@ -43,7 +43,7 @@ backend_config:
   connector: standard
   connector_config:
     scheme: http
-    host: solr
+    host: localhost
     port: 8983
     path: /
     core: ISLANDORA

--- a/config/sync/views.view.solr_search_content.yml
+++ b/config/sync/views.view.solr_search_content.yml
@@ -357,7 +357,7 @@ display:
           prefix: ''
           suffix: ''
           link_to_item: false
-          use_highlighting: false
+          use_highlighting: true
           multi_type: separator
           multi_separator: ', '
           format_plural_values: {  }
@@ -428,7 +428,7 @@ display:
           fallback_handler: search_api
           fallback_options:
             link_to_item: false
-            use_highlighting: false
+            use_highlighting: true
             multi_type: separator
             multi_separator: ', '
         field_linked_agent_name:
@@ -498,7 +498,7 @@ display:
           fallback_handler: search_api
           fallback_options:
             link_to_item: false
-            use_highlighting: false
+            use_highlighting: true
             multi_type: separator
             multi_separator: ', '
         field_description:
@@ -537,7 +537,7 @@ display:
             strip_tags: false
             trim: true
             preserve_tags: ''
-            html: false
+            html: true
           element_type: ''
           element_class: field__item
           element_label_type: ''
@@ -563,11 +563,11 @@ display:
           multi_type: separator
           separator: ', '
           field_api_classes: false
-          field_rendering: true
+          field_rendering: false
           fallback_handler: search_api
           fallback_options:
             link_to_item: false
-            use_highlighting: false
+            use_highlighting: true
             multi_type: separator
             multi_separator: ', '
         processed:
@@ -620,7 +620,7 @@ display:
           empty_zero: false
           hide_alter_empty: true
           link_to_item: false
-          use_highlighting: false
+          use_highlighting: true
           multi_type: separator
           multi_separator: ', '
         search_api_excerpt:
@@ -631,7 +631,7 @@ display:
           group_type: group
           admin_label: ''
           plugin_id: search_api
-          label: ''
+          label: 'Full Text'
           exclude: false
           alter:
             alter_text: false
@@ -661,15 +661,15 @@ display:
             preserve_tags: ''
             html: false
           element_type: ''
-          element_class: ''
+          element_class: field__item
           element_label_type: ''
-          element_label_class: ''
-          element_label_colon: false
+          element_label_class: field__label
+          element_label_colon: true
           element_wrapper_type: ''
           element_wrapper_class: ''
           element_default_classes: true
           empty: ''
-          hide_empty: false
+          hide_empty: true
           empty_zero: false
           hide_alter_empty: true
           link_to_item: false


### PR DESCRIPTION
This changes the unnamed full-text-highlighting field to be:
* only showing full text (from the Reverse reference: Media using Media of » Edited Text (field_edited_text) field)
* named "Full text"
* not show up if there's no full text


It changes the rest of the fields in the solr view to use highlighting too, and makes sure that if your term crosses a trimming boundary that the `<strong>` html won't get cut off. 

Sorry about the lock file and the fact that we're still using playbook-based values here - that's the "localhost" line. 
<img width="764" alt="Screenshot 2023-07-06 at 9 44 09 AM" src="https://github.com/kylehuynh205/islandora-starter-site/assets/1943338/0009b8a6-4f65-48f9-a76f-5abd90f9652a">
